### PR TITLE
Clicks on already-selected Adventurer/Agents don't interfere with mov…

### DIFF
--- a/live_visuals.py
+++ b/live_visuals.py
@@ -753,7 +753,6 @@ class GameVisualisation():
                 # we want it to be coloured differently for each player
 #                print("Drawing the filled circle at " +str(location[0])+ ", " +str(location[1])+ " with radius " +str(self.token_size))
                 pygame.draw.circle(self.window, colour, location, self.token_size)
-                self.adventurer_centres.append([(location[0], location[1]), adventurer])
                 if isinstance(adventurer, AdventurerRegular):
                     if adventurer.pirate_token:
                         # we'll outline pirates in black
@@ -762,6 +761,8 @@ class GameVisualisation():
 #                if adventurer in (self.viewed_adventurer, self.current_adventurer):
                 if adventurer == self.viewed_adventurer:
                     pygame.draw.circle(self.window, self.PLAIN_TEXT_COLOUR, location, self.token_size+self.outline_width, self.outline_width)
+                else:
+                    self.adventurer_centres.append([(location[0], location[1]), adventurer]) #We'll retain the centre, to contstruct a hit-box for selecting this Adventurer instead
                 #For the text label we'll change the indent
                 token_label = self.token_font.render(str(adventurers.index(adventurer)+1), 1, token_label_colour)
                 location[0] -= self.token_size // 2
@@ -778,8 +779,10 @@ class GameVisualisation():
                 #Agents will be differentiated by colour, but they will always have the same position because there will only be one per tile
                 agent_shape = pygame.Rect(location[0], location[1]
                   , self.AGENT_SCALE*self.token_size, self.AGENT_SCALE*self.token_size)
-                self.agent_rects.append([(location[0], location[1]
-                  , self.AGENT_SCALE*self.token_size, self.AGENT_SCALE*self.token_size), agent.player])
+                if agent.player != self.viewed_adventurer.player:
+                    self.agent_rects.append([(location[0], location[1]
+                            , self.AGENT_SCALE*self.token_size, self.AGENT_SCALE*self.token_size)
+                        , agent.player])
                 # we'll only outline the Agents that are dispossessed
                 if isinstance(agent, AgentRegular) and agent.is_dispossessed:
                         pygame.draw.rect(self.window, colour, agent_shape, self.outline_width)

--- a/players_human.py
+++ b/players_human.py
@@ -30,6 +30,8 @@ class PlayerHuman(Player):
                            , "buy":None
                            , "attack":None
                            }
+        self.follow_route = []
+        self.destination = None
     
     def establish_moves(self, adventurer):
         '''Checks the available moves away from their tile for an adventurer and provides suitable highlights, as well as a mapping from coordinates to compass points
@@ -128,7 +130,7 @@ class PlayerHuman(Player):
                 #As about to complete a route to the city, turn off route-following mode
                 self.follow_route = []
                 self.destination = None
-#                self.clear_fixed_response()
+##                self.clear_fixed_response()
             return self.move_to_tile(adventurer, next_tile)
         
         #If Actions were skipped for a queued move, then carry it out and start checking actions with input again
@@ -223,10 +225,8 @@ class PlayerHuman(Player):
                     if play_area.get(destination_coords[0]):
                         self.destination = play_area[destination_coords[0]].get(destination_coords[1])
 #                    print("Setting out on route of length "+str(len(self.follow_route)))
-#                    self.fixed_responses = {"rest":True
-#                               , "buy":None #Break the automatic following and let the player decide
-#                               , "attack":False
-#                               }
+#                    if self.fixed_responses["rest"] is None:
+#                        self.fixed_responses["rest"] = True #
                     #Remove the route up until the current tile
                     while not self.follow_route[0] == adventurer.current_tile:
                             self.follow_route.pop(0)
@@ -456,6 +456,16 @@ class PlayerHuman(Player):
             self.fast_forward = True
             self.queued_move = move_map[move_coords[0]].get(move_coords[1])
             action_location = None
+            #If a move was chosen instead of an Action during route-following, then this means departing from the route
+            self.follow_route = []
+            self.destination = None
+#            longitude = game.play_area.get(move_coords[0])
+#            if longitude is not None:
+#                tile = longitude.get(move_coords[1])
+#                if tile is not None and tile not in self.follow_route:
+#                    #This was a successful departure from the route
+#                    self.follow_route = []
+#                    self.destination = None
         else:
             print(self.colour.capitalize()+" player chose coordinates away from the tile where their Adventurer can "+action_type)
             action_location = None


### PR DESCRIPTION
…e/action choices. Route following is now only broken by active choice to move instead of a prompted action on the route.